### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action/indexer.php
+++ b/action/indexer.php
@@ -17,7 +17,7 @@ class action_plugin_subjectindex_indexer extends DokuWiki_Action_Plugin {
     /**
      * Register its handlers with the DokuWiki's event controller
      */
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
         $controller->register_hook('INDEXER_PAGE_ADD', 'AFTER', $this, 'handle');
     }
 

--- a/syntax/entry.php
+++ b/syntax/entry.php
@@ -56,7 +56,7 @@ class syntax_plugin_subjectindex_entry extends DokuWiki_Syntax_Plugin {
 	}
 
 
-	function handle($match, $state, $pos, &$handler) {
+	function handle($match, $state, $pos, Doku_Handler $handler) {
 
         if ($this->matcher->match($match) === true) {
             $item          = $this->matcher->first;
@@ -82,7 +82,7 @@ class syntax_plugin_subjectindex_entry extends DokuWiki_Syntax_Plugin {
 
     // *************************************
 
-	function render($mode, &$renderer, $data) {
+	function render($mode, Doku_Renderer $renderer, $data) {
 
         if ($mode == 'xhtml') {
             // just re-display a failed match

--- a/syntax/ignore.php
+++ b/syntax/ignore.php
@@ -42,13 +42,13 @@ class syntax_plugin_subjectindex_ignore extends DokuWiki_Syntax_Plugin {
 	}
 
 
-	function handle($match, $state, $pos, &$handler) {
+	function handle($match, $state, $pos, Doku_Handler $handler) {
        // For use by indexer only in raw wiki text, not for display
         return $match;
 	}
 
 
-	function render($mode, &$renderer, $data) {
+	function render($mode, Doku_Renderer $renderer, $data) {
         if ($mode == 'xhtml') {
             $renderer->doc .= '';
         } else {

--- a/syntax/index.php
+++ b/syntax/index.php
@@ -42,7 +42,7 @@ class syntax_plugin_subjectindex_index extends DokuWiki_Syntax_Plugin {
     }
 
 
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         global $ID;
 
         $match = substr($match, 15, -2); // strip "{{subjectindex>...}}" markup
@@ -119,7 +119,7 @@ class syntax_plugin_subjectindex_index extends DokuWiki_Syntax_Plugin {
     }
 
 
-    function render($mode, &$renderer, $opt) {
+    function render($mode, Doku_Renderer $renderer, $opt) {
         if ($mode == 'xhtml') {
             $renderer->info['cache'] = false;
 


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
