### PR TITLE
Update EntryTag.php

### DIFF
--- a/plugins/EntryTag.php
+++ b/plugins/EntryTag.php
@@ -14,8 +14,8 @@ class SI_EntryTag extends SI_Entry {
     public $section = 1;
 
     // first is for Dokuwiki syntax parser matching, second for internal lexing
-    public $regex = '(?<=\s|^)\#[^\s]+';
-    private $_regex = '`(?:\s|^)\#([^#*\s]+)(\*?)`';
+    public $regex = '(?<=[\s|]|^)\#[^\s|]+';
+    private $_regex = '`(?:[\s|]|^)\#([^#*\s|]+)(\*?)`';
 
 
     function match($text) {
@@ -27,7 +27,7 @@ class SI_EntryTag extends SI_Entry {
                 $item = &$this->items[];
                 $tag = $match[1];
                 $item['entry'] = $tag;
-                $item['display'] = str_replace('_', ' ', $tag);  // swap '_' for spaces for display
+                $item['display'] = '#' . str_replace('_', ' ', $tag);  // swap '_' for spaces for display
                 $item['section'] = $this->section;
                 $item['type'] = $this->type;
                 $item['star'] = $match[2] == '*' ? true : false;


### PR DESCRIPTION
Hi there,

These are some modifications I made to my local copy. Hopefully they make sense and are of value to the project.

1. I have found that tags abutting a pipe '|' (inside a DOKUWIKI syntax table cell) would not be found. I updated my regex (lines 17&18) to also end matching if it hits a pipe at the start or end of the pattern.

2. I'm using hashtags mainly but the '#' is absent when they are displayed on the wiki page (as entry, not index) so re-inserted the '#' at the start of the display value.