### PR TITLE
Fixes disappearing entries #17 (sorry incorrect PR!)

### DIFF
--- a/inc/common.php
+++ b/inc/common.php
@@ -109,7 +109,7 @@ class SI_Index implements Iterator {
             $fpaths = preg_grep('`' . $regex . '`', $fpaths);
         }
         if ($pid !== null) {
-            $fpaths = array_intersect_key($this->paths, preg_grep('/' . $pid . '/', $this->pids));
+            $fpaths = array_intersect_key($this->paths, preg_grep('/^' . $pid . '$/', $this->pids));
         }
         $fpids = array_intersect_key($this->pids, $fpaths);
         $index = new SI_Index($fpaths, $fpids);

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,6 +1,6 @@
 base    subjectindex
 author  Symon Bent, Michael Sy.
-email   hendrybadao@gmail.com
+email   
 date    2022-10-06
 name    Subjectindex Plugin
 desc    Hierarchical structured tagging: create A-Z subject index pages for your wiki, based on in-place entries|tags in pages.

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base    subjectindex
-author  Symon Bent
+author  Symon Bent, Michael Sy.
 email   hendrybadao@gmail.com
-date    2014-05-04
+date    2022-10-06
 name    Subjectindex Plugin
 desc    Hierarchical structured tagging: create A-Z subject index pages for your wiki, based on in-place entries|tags in pages.
-url     http://wiki.splitbrain.org/plugin:subjectindex
+url     https://github.com/Michaelsy/subjectindex/zipball/master


### PR DESCRIPTION
The match must only be valid if there is a complete match. Otherwise, too many entries are selected and removed via the update() method, which leads to the bug.