### PR TITLE
Fixes disappearing entries #17

### DIFF
--- a/inc/common.php
+++ b/inc/common.php
@@ -109,7 +109,7 @@ class SI_Index implements Iterator {
             $fpaths = preg_grep('`' . $regex . '`', $fpaths);
         }
         if ($pid !== null) {
-            $fpaths = array_intersect_key($this->paths, preg_grep('/' . $pid . '/', $this->pids));
+            $fpaths = array_intersect_key($this->paths, preg_grep('/^' . $pid . '$/', $this->pids));
         }
         $fpids = array_intersect_key($this->pids, $fpaths);
         $index = new SI_Index($fpaths, $fpids);


### PR DESCRIPTION
The match must only be valid if there is a complete match. Otherwise, too many entries are selected and removed via the update() method, which leads to the bug.

\- Michael Sy.